### PR TITLE
Fixed issue with compressed BAMs. 

### DIFF
--- a/server/static/upload.js
+++ b/server/static/upload.js
@@ -230,7 +230,7 @@ $(function () {
         var fileType = 'Other';
         for (var ext in fileExtensions) {
             if (fileExtensions.hasOwnProperty(ext) &&
-                file.name.toLowerCase().indexOf(ext) > -1) {
+                file.name.toLowerCase().endsWith(ext)) {
                 fileType = fileExtensions[ext];
             }
         }

--- a/server/utils.py
+++ b/server/utils.py
@@ -231,27 +231,27 @@ def get_or_create_file(data):
     if not file:
         file = File()
 
-        file.identifier = data.get('identifier')
-        file.filename = data.get('filename')
-        file.total_size = data.get('total_size')
-        file.file_type = data.get('file_type')
-        file.user_id = user.user_id
-        file.access_id = access.id
-        file.readset = data.get('readset')
-        file.platform = data.get('platform')
-        file.run_type = data.get('run_type')
-        file.capture_kit = data.get('capture_kit')
-        file.library = data.get('library')
-        file.reference = data.get('reference')
-        file.upload_status = 'ongoing'
-        file.upload_start_date = dt.datetime.today()
+    file.identifier = data.get('identifier')
+    file.filename = data.get('filename')
+    file.total_size = data.get('total_size')
+    file.file_type = data.get('file_type')
+    file.user_id = user.user_id
+    file.access_id = access.id
+    file.readset = data.get('readset')
+    file.platform = data.get('platform')
+    file.run_type = data.get('run_type')
+    file.capture_kit = data.get('capture_kit')
+    file.library = data.get('library')
+    file.reference = data.get('reference')
+    file.upload_status = 'ongoing'
+    file.upload_start_date = dt.datetime.today()
 
-        # Attach the file to this sample and access objects
-        sample.files.append(file)
-        access.files.append(file)
+    # Attach the file to this sample and access objects
+    sample.files.append(file)
+    access.files.append(file)
 
-        db.session.add(file)
-        db.session.commit()
+    db.session.add(file)
+    db.session.commit()
 
     return file
 


### PR DESCRIPTION
File extensions are now detected by looking at the end of the filename, not just anywhere within the file.
There was also an issue with uploads being refused if the file was in the database but not listed as ongoing. This was fixed by updating metadata including status when a 'start upload' request is received. 